### PR TITLE
Tweepy 3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
 
     install_requires=[
-        "tweepy >= 3.0"
+        "tweepy >= 3.7"
     ],
     test_suite="tests",
     tests_require=["mock == 1.0.1"],

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -72,7 +72,7 @@ class TestDynamicTwitterStream(TestCase):
                                                       retry_count=self.retry_count)
 
         # It should be using the sample endpoint
-        self.tweepy_stream_instance.sample.assert_called_once_with(async=True, languages=None)        
+        self.tweepy_stream_instance.sample.assert_called_once_with(is_async=True, languages=None)        
 
     def test_start_with_languages(self):
 
@@ -89,7 +89,7 @@ class TestDynamicTwitterStream(TestCase):
         self.stream.start_stream()
 
         # It should be using the sample endpoint with languages
-        self.tweepy_stream_instance.sample.assert_called_once_with(async=True, languages=languages)
+        self.tweepy_stream_instance.sample.assert_called_once_with(is_async=True, languages=languages)
 
 
     def test_start_stream_with_terms(self):
@@ -107,7 +107,7 @@ class TestDynamicTwitterStream(TestCase):
                                                       timeout=90,
                                                       retry_count=self.retry_count)
         # Should start the filter with the terms
-        self.tweepy_stream_instance.filter.assert_called_once_with(track=self.term_list, async=True, languages=None)
+        self.tweepy_stream_instance.filter.assert_called_once_with(track=self.term_list, is_async=True, languages=None)
 
 
     def test_stop_stream_not_started(self):

--- a/twitter_monitor/stream.py
+++ b/twitter_monitor/stream.py
@@ -114,10 +114,10 @@ class DynamicTwitterStream(object):
                 logger.info("  %s", repr(tracking_terms))
                 
                 # Launch it in a new thread
-                self.stream.filter(track=tracking_terms, async=True, languages=self.languages)
+                self.stream.filter(track=tracking_terms, is_async=True, languages=self.languages)
             else:
                 logger.info("Starting new unfiltered stream")
-                self.stream.sample(async=True, languages=self.languages)
+                self.stream.sample(is_async=True, languages=self.languages)
                 
     def stop_stream(self):
         """


### PR DESCRIPTION
In the version 3.7.0 of Tweepy, the package has change ``àsync`` for ``is_async`` in the filtering options.